### PR TITLE
Feat: Update TrustedIssuer Hash Calculation + Update to Java 21

### DIFF
--- a/.github/workflows/ci-dependency-check.yml
+++ b/.github/workflows/ci-dependency-check.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: adopt
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: adopt
       - uses: actions/checkout@v3
         with:
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: adopt
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-pullrequest.yml
+++ b/.github/workflows/ci-pullrequest.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: adopt
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/setup-java@v3
       with:
-        java-version: 17
+        java-version: 21
         distribution: adopt
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci-sonar.yml
+++ b/.github/workflows/ci-sonar.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: adopt
       - uses: actions/checkout@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,14 @@
 
     <groupId>eu.europa.ec.dgc</groupId>
     <artifactId>ddcc-gateway-lib</artifactId>
-    <version>2.0.2</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-parent</artifactId>
+        <version>2023.0.2</version>
+    </parent>
 
     <name>ddcc-gateway-lib</name>
     <description>Library with common used methods and classes for Digital Documentation Covid Certificate Gateway.
@@ -17,24 +23,21 @@
     </organization>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <!-- charset -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- dependencies -->
-        <owasp.version>9.0.2</owasp.version>
-        <bcpkix.version>1.76</bcpkix.version>
-        <lombok.version>1.18.30</lombok.version>
-        <mapstruct.version>1.5.3.Final</mapstruct.version>
-        <commonsio.version>2.11.0</commonsio.version>
-        <cbor.version>4.5.2</cbor.version>
-        <mockwebserver.version>4.12.0</mockwebserver.version>
-        <plugin.checkstyle.version>3.2.1</plugin.checkstyle.version>
-        <plugin.sonar.version>3.9.1.2184</plugin.sonar.version>
-        <plugin.surefire.version>3.2.2</plugin.surefire.version>
-        <plugin.jacoco.version>0.8.11</plugin.jacoco.version>
-        <spring.boot.version>3.0.13</spring.boot.version>
+        <owasp.version>9.2.0</owasp.version>
+        <bcpkix.version>1.78.1</bcpkix.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <commonsio.version>2.16.1</commonsio.version>
+        <cbor.version>4.5.4</cbor.version>
+        <plugin.checkstyle.version>3.4.0</plugin.checkstyle.version>
+        <plugin.jacoco.version>0.8.12</plugin.jacoco.version>
+<!--        <jackson.version>2.15.4</jackson.version>-->
+<!--        <lombok.version></lombok.version>-->
 
         <!-- license -->
         <license.projectName>WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib</license.projectName>
@@ -71,30 +74,23 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${spring.boot.version}</version>
-<!--            <optional>true</optional>-->
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
-            <version>${spring.boot.version}</version>
-<!--            <optional>true</optional>-->
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
-            <version>4.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring.boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-httpclient</artifactId>
-            <version>13.1</version>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>
@@ -104,7 +100,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -125,17 +120,16 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.3</version>
+            <version>${jackson-bom.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.14.3</version>
+            <version>${jackson-bom.version}</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>${mockwebserver.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -151,17 +145,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${plugin.surefire.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>2.3.0</version>
+                    <version>2.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -261,6 +249,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
                 <configuration>
                     <annotationProcessorPaths>
                         <path>
@@ -276,7 +265,7 @@
                         <path>
                             <groupId>org.springframework.boot</groupId>
                             <artifactId>spring-boot-configuration-processor</artifactId>
-                            <version>${spring.boot.version}</version>
+                            <version>${project.parent.parent.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/src/main/java/eu/europa/ec/dgc/DgcLibAutoConfiguration.java
+++ b/src/main/java/eu/europa/ec/dgc/DgcLibAutoConfiguration.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayConnectorUtils.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayConnectorUtils.java
@@ -361,11 +361,10 @@ class DgcGatewayConnectorUtils {
     }
 
     private String getHashData(TrustedIssuerDto trustedIssuerDto) {
-        return trustedIssuerDto.getUuid() + HASH_SEPARATOR
-            + trustedIssuerDto.getCountry() + HASH_SEPARATOR
+        return trustedIssuerDto.getCountry() + HASH_SEPARATOR
             + trustedIssuerDto.getName() + HASH_SEPARATOR
             + trustedIssuerDto.getUrl() + HASH_SEPARATOR
-            + trustedIssuerDto.getType().name() + HASH_SEPARATOR;
+            + trustedIssuerDto.getType().name();
     }
 
     @RequiredArgsConstructor

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayConnectorUtils.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayConnectorUtils.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayCountryListDownloadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayCountryListDownloadConnector.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayDownloadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayDownloadConnector.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayDownloadConnectorBuilder.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayDownloadConnectorBuilder.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayRevocationListDownloadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayRevocationListDownloadConnector.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayRevocationListUploadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayRevocationListUploadConnector.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayTrustedIssuerDownloadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayTrustedIssuerDownloadConnector.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayUploadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayUploadConnector.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayValidationRuleDownloadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayValidationRuleDownloadConnector.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayValidationRuleUploadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayValidationRuleUploadConnector.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayValueSetDownloadConnector.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/DgcGatewayValueSetDownloadConnector.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/client/DgcGatewayConnectorRestClient.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/client/DgcGatewayConnectorRestClient.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/client/DgcGatewayConnectorRestClientConfig.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/client/DgcGatewayConnectorRestClientConfig.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/config/DgcGatewayConnectorConfigProperties.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/config/DgcGatewayConnectorConfigProperties.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/config/DgcGatewayConnectorKeystore.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/config/DgcGatewayConnectorKeystore.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/CertificateTypeDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/CertificateTypeDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/ProblemReportDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/ProblemReportDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/RevocationBatchDeleteRequestDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/RevocationBatchDeleteRequestDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/RevocationBatchDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/RevocationBatchDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/RevocationBatchListDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/RevocationBatchListDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/RevocationHashTypeDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/RevocationHashTypeDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/TrustListItemDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/TrustListItemDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/TrustedCertificateTrustListDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/TrustedCertificateTrustListDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/TrustedIssuerDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/TrustedIssuerDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/TrustedReferenceDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/TrustedReferenceDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/ValidationRuleDto.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/dto/ValidationRuleDto.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/exception/RevocationBatchDownloadException.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/exception/RevocationBatchDownloadException.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/exception/RevocationBatchGoneException.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/exception/RevocationBatchGoneException.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/exception/RevocationBatchParseException.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/exception/RevocationBatchParseException.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/iterator/DgcGatewayRevocationListDownloadIterator.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/iterator/DgcGatewayRevocationListDownloadIterator.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/mapper/TrustListMapper.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/mapper/TrustListMapper.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/mapper/TrustedCertificateMapper.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/mapper/TrustedCertificateMapper.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/mapper/TrustedIssuerMapper.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/mapper/TrustedIssuerMapper.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/mapper/TrustedReferenceMapper.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/mapper/TrustedReferenceMapper.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/model/CertificateType.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/model/CertificateType.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/model/QueryParameter.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/model/QueryParameter.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/model/TrustListItem.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/model/TrustListItem.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/model/TrustedCertificateTrustListItem.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/model/TrustedCertificateTrustListItem.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/model/TrustedIssuer.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/model/TrustedIssuer.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/model/TrustedReference.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/model/TrustedReference.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/model/ValidationRule.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/model/ValidationRule.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/gateway/connector/model/ValidationRulesByCountry.java
+++ b/src/main/java/eu/europa/ec/dgc/gateway/connector/model/ValidationRulesByCountry.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/Base45Encoder.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/Base45Encoder.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/CopyDigest.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/CopyDigest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/DccBuilderBase.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/DccBuilderBase.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/DccRecoveryBuilder.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/DccRecoveryBuilder.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/DccTestBuilder.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/DccTestBuilder.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/DccVaccinationBuilder.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/DccVaccinationBuilder.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/DgcCryptedFinalizer.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/DgcCryptedFinalizer.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/DgcCryptedPublisher.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/DgcCryptedPublisher.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/DgcGenerator.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/DgcGenerator.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/DgcSigner.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/DgcSigner.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/DgciGenerator.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/DgciGenerator.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/dto/DgcData.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/dto/DgcData.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/generation/dto/DgcInitData.java
+++ b/src/main/java/eu/europa/ec/dgc/generation/dto/DgcInitData.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/signing/SignedByteArrayMessageBuilder.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedByteArrayMessageBuilder.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/signing/SignedByteArrayMessageParser.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedByteArrayMessageParser.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/signing/SignedCertificateMessageBuilder.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedCertificateMessageBuilder.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/signing/SignedCertificateMessageParser.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedCertificateMessageParser.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/signing/SignedMessageBuilder.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedMessageBuilder.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/signing/SignedMessageParser.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedMessageParser.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/signing/SignedStringMessageBuilder.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedStringMessageBuilder.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/signing/SignedStringMessageParser.java
+++ b/src/main/java/eu/europa/ec/dgc/signing/SignedStringMessageParser.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/europa/ec/dgc/utils/CertificateUtils.java
+++ b/src/main/java/eu/europa/ec/dgc/utils/CertificateUtils.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/DgcLibAutoConfigurationTest.java
+++ b/src/test/java/eu/europa/ec/dgc/DgcLibAutoConfigurationTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/CountryListDownloadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/CountryListDownloadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/DdccDownloadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/DdccDownloadConnectorTest.java
@@ -657,11 +657,10 @@ class DdccDownloadConnectorTest {
     }
 
     private String getHashData(TrustedIssuerDto trustedIssuerDto) {
-        return trustedIssuerDto.getUuid() + ";"
-            + trustedIssuerDto.getCountry() + ";"
+        return trustedIssuerDto.getCountry() + ";"
             + trustedIssuerDto.getName() + ";"
             + trustedIssuerDto.getUrl() + ";"
-            + trustedIssuerDto.getType().name() + ";";
+            + trustedIssuerDto.getType().name();
     }
 
 }

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/DdccDownloadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/DdccDownloadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/DownloadConnectorBuilderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/DownloadConnectorBuilderTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/DownloadConnectorCacheTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/DownloadConnectorCacheTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/DownloadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/DownloadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/DownloadConnectorUtilsTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/DownloadConnectorUtilsTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/RevocationListDownloadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/RevocationListDownloadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/RevocationListUploadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/RevocationListUploadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/SpringBootTestApplication.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/SpringBootTestApplication.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/TrustedIssuerDownloadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/TrustedIssuerDownloadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/UploadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/UploadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/ValidationRuleDownloadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/ValidationRuleDownloadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/ValidationRuleUploadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/ValidationRuleUploadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/gateway/connector/ValueSetDownloadConnectorTest.java
+++ b/src/test/java/eu/europa/ec/dgc/gateway/connector/ValueSetDownloadConnectorTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/generation/Base45EncoderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/generation/Base45EncoderTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/generation/DccRecoveryBuilderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/generation/DccRecoveryBuilderTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/generation/DccTestBuilderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/generation/DccTestBuilderTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/generation/DccVaccinationBuilderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/generation/DccVaccinationBuilderTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/generation/DgcCryptedPublisherTest.java
+++ b/src/test/java/eu/europa/ec/dgc/generation/DgcCryptedPublisherTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/generation/DgcSignerTest.java
+++ b/src/test/java/eu/europa/ec/dgc/generation/DgcSignerTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/generation/KeyHelper.java
+++ b/src/test/java/eu/europa/ec/dgc/generation/KeyHelper.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/signing/DeprecatedSignedCertificateMessageBuilderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/signing/DeprecatedSignedCertificateMessageBuilderTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/signing/SignedByteArrayMessageBuilderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/signing/SignedByteArrayMessageBuilderTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/signing/SignedByteArrayMessageParserTest.java
+++ b/src/test/java/eu/europa/ec/dgc/signing/SignedByteArrayMessageParserTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/signing/SignedCertificateMessageBuilderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/signing/SignedCertificateMessageBuilderTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/signing/SignedCertificateMessageParserTest.java
+++ b/src/test/java/eu/europa/ec/dgc/signing/SignedCertificateMessageParserTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/signing/SignedStringMessageBuilderTest.java
+++ b/src/test/java/eu/europa/ec/dgc/signing/SignedStringMessageBuilderTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/signing/SignedStringMessageParserTest.java
+++ b/src/test/java/eu/europa/ec/dgc/signing/SignedStringMessageParserTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/testdata/CertificateTestUtils.java
+++ b/src/test/java/eu/europa/ec/dgc/testdata/CertificateTestUtils.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/testdata/DgcTestKeyStore.java
+++ b/src/test/java/eu/europa/ec/dgc/testdata/DgcTestKeyStore.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/testdata/TrustedIssuerTestHelper.java
+++ b/src/test/java/eu/europa/ec/dgc/testdata/TrustedIssuerTestHelper.java
@@ -49,11 +49,10 @@ public class TrustedIssuerTestHelper {
     }
 
     private String getHashData(TrustedIssuerDto entity) {
-        return entity.getUuid() + ";"
-            + entity.getCountry() + ";"
+        return entity.getCountry() + ";"
             + entity.getName() + ";"
             + entity.getUrl() + ";"
-            + entity.getType().name() + ";";
+            + entity.getType().name();
     }
 
     public String signString(final String hashdata) throws Exception {

--- a/src/test/java/eu/europa/ec/dgc/testdata/TrustedIssuerTestHelper.java
+++ b/src/test/java/eu/europa/ec/dgc/testdata/TrustedIssuerTestHelper.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/eu/europa/ec/dgc/utils/CertificateUtilsTest.java
+++ b/src/test/java/eu/europa/ec/dgc/utils/CertificateUtilsTest.java
@@ -2,7 +2,7 @@
  * ---license-start
  * WHO Digital Documentation Covid Certificate Gateway Service / ddcc-gateway-lib
  * ---
- * Copyright (C) 2022 T-Systems International GmbH and all other contributors
+ * Copyright (C) 2022 - 2024 T-Systems International GmbH and all other contributors
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Update TrustedIssuer Hash Calculation to not use UUID anymore
* Update to Java 21
* Update Dependencies
* Refactor pom.xml